### PR TITLE
Added support for front panel port prefix regex

### DIFF
--- a/src/swsssdk/port_util.py
+++ b/src/swsssdk/port_util.py
@@ -5,7 +5,14 @@ import swsssdk
 import re
 
 
-SONIC_ETHERNET_RE_PATTERN = "^Ethernet(\d+)$"
+from swsscommon.swsscommon import FRONT_PANEL_PORT_REGEX
+
+# Following is a list of regexs that match different interfaces type
+# the convention is to have the port index in the end of the name so it can
+# be retrived with match.groups()[-1]
+
+# front panel ports, e.g. Ethernet4
+SONIC_FRONT_PANEL_RE_PATTERN = FRONT_PANEL_PORT_REGEX
 """
 Ethernet-BP refers to BackPlane interfaces
 in multi-asic platform.
@@ -18,7 +25,7 @@ SONIC_ETHERNET_IB_RE_PATTERN = "^Ethernet-IB(\d+)$"
 SONIC_ETHERNET_REC_RE_PATTERN = "^Ethernet-Rec(\d+)$"
 
 class BaseIdx:
-    ethernet_base_idx = 1
+    front_panel_base_idx = 1
     vlan_interface_base_idx = 2000
     ethernet_bp_base_idx = 9000
     portchannel_base_idx = 1000
@@ -52,7 +59,7 @@ def get_index_from_str(if_name):
     Ethernet_Rec N = N + 12000
     """
     patterns = {
-        SONIC_ETHERNET_RE_PATTERN: BaseIdx.ethernet_base_idx,
+        SONIC_FRONT_PANEL_RE_PATTERN: BaseIdx.front_panel_base_idx,
         SONIC_ETHERNET_BP_RE_PATTERN: BaseIdx.ethernet_bp_base_idx,
         SONIC_VLAN_RE_PATTERN: BaseIdx.vlan_interface_base_idx,
         SONIC_PORTCHANNEL_RE_PATTERN: BaseIdx.portchannel_base_idx,
@@ -64,7 +71,7 @@ def get_index_from_str(if_name):
     for pattern, baseidx in patterns.items():
         match = re.match(pattern, if_name)
         if match:
-            return int(match.group(1)) + baseidx
+            return int(match.groups()[-1]) + baseidx
 
 def get_interface_oid_map(db, blocking=True):
     """


### PR DESCRIPTION
What I did
Removed the dependency on the "Ethernet" string in the SONiC code base and added support
for extending the front panel port name pattern.

How I did it

Introduced FRONT_PANEL_PORT_PREFIX_REGEX that extends the old FRONT_PANEL_PORT_PREFIX ("Ethernet")
Updated all the relevant usage of the "Ethernet" throughout the code base to use the new regex pattern
How to verify it
Pass all UT and CI testing.

Why I did it
In order to support distinguishing between different types of front panel ports in a maintainable fashion.
Specifically, we are planning to bring up a system with 'service' ports (in addition to the regular ethernet data ports) - these
are lower speed ports that used for connection to accelerators, internal loopbacks and more.

**- Related Commits and Merge Strategy**
_This is part of a group of related commits and should be merged **after https://github.com/Azure/sonic-swss-common/pull/598 and https://github.com/Azure/sonic-buildimage/pull/10471**._

The full merge order is:

1. swss-common - https://github.com/Azure/sonic-swss-common/pull/598
2. sonic-buildimage - https://github.com/Azure/sonic-buildimage/pull/10471
3. swsssdk - https://github.com/Azure/sonic-py-swsssdk/pull/121
4. all the rest
     [ https://github.com/Azure/sonic-utilities/pull/2127](https://github.com/Azure/sonic-utilities/pull/2127)
     [ https://github.com/Azure/sonic-snmpagent/pull/251](https://github.com/Azure/sonic-snmpagent/pull/251)
     [ https://github.com/Azure/sonic-swss/pull/2223](https://github.com/Azure/sonic-swss/pull/2223)
     [ https://github.com/Azure/sonic-platform-daemons/pull/252](https://github.com/Azure/sonic-platform-daemons/pull/252)
     [ https://github.com/Azure/sonic-platform-common/pull/274](https://github.com/Azure/sonic-platform-common/pull/274)
