### PR TITLE
Fix UT test_BlockUseSwsssdk()

### DIFF
--- a/test/test_moduleLoad.py
+++ b/test/test_moduleLoad.py
@@ -42,6 +42,6 @@ def test_BlockUseSwsssdk():
     try:
         subprocess.check_output(["python", "-c", "import swsssdk;exit()"], stderr=subprocess.STDOUT, cwd=swsssdk_path)
     except subprocess.CalledProcessError as e:
-        result = e.output
+        result = e.output.decode("utf-8")
 
     assert "deprecated" in result

--- a/test/test_moduleLoad.py
+++ b/test/test_moduleLoad.py
@@ -38,6 +38,6 @@ class Test_load_sonic_db_config(TestCase):
 def test_BlockUseSwsssdk():
     # Import swsssdk will throw exception with deprecated message.
     swsssdk_path = os.path.join(modules_path, 'src')
-    result = subprocess.run(["python", "-c", "import swsssdk;exit()"], capture_output=True, cwd=swsssdk_path)
+    result = subprocess.check_output(["python", "-c", "import swsssdk;exit()"], stderr=subprocess.STDOUT, cwd=swsssdk_path)
 
-    assert "deprecated" in result.stderr.decode("utf-8")
+    assert "deprecated" in result

--- a/test/test_moduleLoad.py
+++ b/test/test_moduleLoad.py
@@ -39,8 +39,13 @@ def test_BlockUseSwsssdk():
     # Import swsssdk will throw exception with deprecated message.
     swsssdk_path = os.path.join(modules_path, 'src')
     result = None
+    python_command = "python"
+    
+    if sys.version_info.major == 3:
+        python_command = "python3"
+
     try:
-        subprocess.check_output(["python", "-c", "import swsssdk;exit()"], stderr=subprocess.STDOUT, cwd=swsssdk_path)
+        subprocess.check_output([python_command, "-c", "import swsssdk;exit()"], stderr=subprocess.STDOUT, cwd=swsssdk_path)
     except subprocess.CalledProcessError as e:
         result = e.output.decode("utf-8")
 

--- a/test/test_moduleLoad.py
+++ b/test/test_moduleLoad.py
@@ -38,6 +38,10 @@ class Test_load_sonic_db_config(TestCase):
 def test_BlockUseSwsssdk():
     # Import swsssdk will throw exception with deprecated message.
     swsssdk_path = os.path.join(modules_path, 'src')
-    result = subprocess.check_output(["python", "-c", "import swsssdk;exit()"], stderr=subprocess.STDOUT, cwd=swsssdk_path)
+    result = None
+    try:
+        subprocess.check_output(["python", "-c", "import swsssdk;exit()"], stderr=subprocess.STDOUT, cwd=swsssdk_path)
+    except subprocess.CalledProcessError as e:
+        result = e.output
 
     assert "deprecated" in result


### PR DESCRIPTION
#### Why I did it
Fix this issue: https://github.com/sonic-net/sonic-buildimage/issues/12558
UT failed under python2: test_BlockUseSwsssdk()
>       result = subprocess.run(["python", "-c", "import swsssdk;exit()"], capture_output=True, cwd=swsssdk_path)
E       AttributeError: 'module' object has no attribute 'run'

#### How I did it
Update UT to use subprocess.check_output(), which support by both python3 and python2.

#### How to verify it
Pass all UT.

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
Fix UT test_BlockUseSwsssdk()

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

