### PR TITLE
Remove LOGLEVEL DB since is no longer used

### DIFF
--- a/src/swsssdk/config/database_config.json
+++ b/src/swsssdk/config/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/src/swsssdk/sonic_db_dump_load.py
+++ b/src/swsssdk/sonic_db_dump_load.py
@@ -113,7 +113,7 @@ def sonic_db_dump_load():
         parser.add_option('-A', '--use-expireat', help='use EXPIREAT rather than TTL/EXPIRE', action='store_true')
     else:
         parser.add_option('-l', '--load', help='load data into redis (default is to dump data from redis)', action='store_true')
-        parser.add_option('-n', '--dbname', help='dump DATABASE (APPL_DB/ASIC_DB/COUNTERS_DB/LOGLEVEL_DB/CONFIG_DB...)')
+        parser.add_option('-n', '--dbname', help='dump DATABASE (APPL_DB/ASIC_DB/COUNTERS_DB/CONFIG_DB...)')
         parser.add_option('-t', '--conntype', help='indicate redis connection type (tcp[default] or unix_socket)', default='tcp')
         parser.add_option('-k', '--keys', help='dump only keys matching specified glob-style pattern')
         parser.add_option('-o', '--output', help='write to OUTPUT instead of stdout (dump mode only)')

--- a/src/swsssdk/sonic_db_dump_load.py
+++ b/src/swsssdk/sonic_db_dump_load.py
@@ -113,7 +113,7 @@ def sonic_db_dump_load():
         parser.add_option('-A', '--use-expireat', help='use EXPIREAT rather than TTL/EXPIRE', action='store_true')
     else:
         parser.add_option('-l', '--load', help='load data into redis (default is to dump data from redis)', action='store_true')
-        parser.add_option('-n', '--dbname', help='dump DATABASE (APPL_DB/ASIC_DB/COUNTERS_DB/CONFIG_DB...)')
+        parser.add_option('-n', '--dbname', help='dump DATABASE (APPL_DB/ASIC_DB/COUNTERS_DB/LOGLEVEL_DB/CONFIG_DB...)')
         parser.add_option('-t', '--conntype', help='indicate redis connection type (tcp[default] or unix_socket)', default='tcp')
         parser.add_option('-k', '--keys', help='dump only keys matching specified glob-style pattern')
         parser.add_option('-o', '--output', help='write to OUTPUT instead of stdout (dump mode only)')

--- a/test/config/database_config.json
+++ b/test/config/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",


### PR DESCRIPTION
This PR is part of the following HLD:
Persistent loglevel HLD: https://github.com/sonic-net/SONiC/pull/1041
**- What I did**
Deleted the LOGLEVEL_DB.
After the Logger tables moved from the LOGLEVEL_DB to the CONFIG_DB and the jinja2_cache was deleted the LOGLEVEL_DB is not in use.
**- How I did it**
Removed the LOGLEVEL_DB from the SONiC code

**- How to verify it**
All tests were passed