### PR TITLE
replace exit() with sys.exit()

### DIFF
--- a/src/swsssdk/sonic_db_dump_load.py
+++ b/src/swsssdk/sonic_db_dump_load.py
@@ -130,10 +130,10 @@ def sonic_db_dump_load():
     if action == DUMP:
         if len(args) > 0:
             parser.print_help()
-            exit(4)
+            sys.exit(4)
         do_dump(options)
     else:
         if len(args) > 1:
             parser.print_help()
-            exit(4)
+            sys.exit(4)
         do_load(options, args)

--- a/test/sonic_db_dump_load_test.py
+++ b/test/sonic_db_dump_load_test.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(modules_path, 'src'))
+import swsssdk
+
+class TestSonicDbDumpLoad(object):
+    def setup(self):
+        print("SETUP")
+
+    @patch('optparse.OptionParser.print_help')
+    @patch('optparse.OptionParser.parse_args', MagicMock(return_value=('options', ['-p'])))
+    @patch('sys.argv', ['dump'])
+    def test_sonic_db_dump_exit(self, mock_print_help):
+        with pytest.raises(SystemExit) as e:
+            swsssdk.sonic_db_dump_load()
+        mock_print_help.assert_called_once()
+        assert e.value.code == 4
+
+    @patch('optparse.OptionParser.print_help')
+    @patch('optparse.OptionParser.parse_args', MagicMock(return_value=('options', ['-p', '-o'])))
+    @patch('sys.argv', ['load'])
+    def test_sonic_db_load_exit(self, mock_print_help):
+        with pytest.raises(SystemExit) as e:
+            swsssdk.sonic_db_dump_load()
+        mock_print_help.assert_called_once()
+        assert e.value.code == 4
+
+    def teardown(self):
+        print("TEARDOWN")
+


### PR DESCRIPTION
**Description**
Replace exit() by sys.exit()

**Motivation and Context**
sys.exit is better than exit, considered good to use in production code.
Ref:
https://stackoverflow.com/questions/6501121/difference-between-exit-and-sys-exit-in-python
https://stackoverflow.com/questions/19747371/python-exit-commands-why-so-many-and-when-should-each-be-used