### PR TITLE
Loosen the redis version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 dependencies = [
-    'redis==4.5.4;python_version >= "3.0"',
+    'redis>=4.5.4;python_version >= "3.0"',
     'redis>=3.5.3;python_version < "3.0"',
     'redis-dump-load',
 ]


### PR DESCRIPTION
The true versions are specified by Dockerfile, such as dockers/docker-config-engine-bullseye/Dockerfile.j2. It may use later versions, we do not want setup.py to install an older version in that case.

See the PR https://github.com/sonic-net/sonic-py-swsssdk/pull/136

