### PR TITLE
unittest - fix import for python 2

### DIFF
--- a/test/sonic_db_dump_load_test.py
+++ b/test/sonic_db_dump_load_test.py
@@ -1,7 +1,11 @@
 import os
 import sys
 import pytest
-from unittest.mock import patch, MagicMock
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+from mock import patch, MagicMock
 
 modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))


### PR DESCRIPTION
Submodule update failed for python 2 because mock import statement is not compatible for python 2
Fix import statement for python 2 and python 3

Passed UT for python 2 and python 3
```
platform linux2 -- Python 2.7.16, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /sonic/src/sonic-py-swsssdk, inifile: pytest.ini
plugins: cov-2.6.0
collected 7 items

test/sonic_db_dump_load_test.py ..                                                     [ 28%]
test/test_moduleLoad.py ....                                                           [ 85%]
test/test_port_util.py .                                                               [100%]


platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /sonic/src/sonic-py-swsssdk, configfile: pytest.ini
plugins: pyfakefs-5.2.2, cov-2.10.1
collected 7 items

test/sonic_db_dump_load_test.py ..                                                     [ 28%]
test/test_moduleLoad.py ....                                                           [ 85%]
test/test_port_util.py .                                                               [100%]
```