### PR TITLE
[actions] Support Semgrep by Github Actions

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,22 @@
+name: Semgrep
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
+      - '201[7-9][0-1][0-9]'
+      - '202[0-9][0-1][0-9]'
+
+jobs:
+  semgrep:
+    if: github.repository_owner == 'sonic-net'
+    name: Semgrep
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - uses: actions/checkout@v3
+      - run: semgrep ci
+        env:
+           SEMGREP_RULES: p/default

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,24 +14,6 @@ pr:
     - master
 
 stages:
-- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-  - stage: Analysis
-    dependsOn: []
-    jobs:
-    - job:
-      displayName: "Semgrep"
-      pool:
-        vmImage: ubuntu-latest
-      steps:
-      - script: |
-          set -ex
-          target_branch=origin/$(System.PullRequest.TargetBranch)
-          files_changed=$(git --no-pager diff $target_branch..HEAD --name-only --diff-filter=d)
-          python -m pip install --upgrade pip
-          pip install semgrep
-          semgrep --config "p/default" --error $files_changed
-        displayName: 'Run Semgrep'
-
 - stage: Build
   jobs:
   - job:


### PR DESCRIPTION
Make Semgrep CI same practice with other SONiC repositories

**Why I did it**
[Semgrep](https://github.com/returntocorp/semgrep) is a static analysis tool to find security vulnerabilities.
When opening a PR or commtting to PR, Semgrep performs a diff-aware scanning, which scans changed files in PRs.
When merging PR, Semgrep performs a full scan on master branch and report all findings.

Ref: - [Supported Language](https://semgrep.dev/docs/supported-languages/#language-maturity) - [Semgrep Rules](https://registry.semgrep.dev/rule)

**How I did it**
Integrate Semgrep into this repository by committing a job configuration file