### PR TITLE
Fixed issue#15359 by adding support of IpaddrToIfIndex MIB

### DIFF
--- a/src/swsssdk/port_util.py
+++ b/src/swsssdk/port_util.py
@@ -16,6 +16,7 @@ SONIC_PORTCHANNEL_RE_PATTERN = "^PortChannel(\d+)$"
 SONIC_MGMT_PORT_RE_PATTERN = "^eth(\d+)$"
 SONIC_ETHERNET_IB_RE_PATTERN = "^Ethernet-IB(\d+)$"
 SONIC_ETHERNET_REC_RE_PATTERN = "^Ethernet-Rec(\d+)$"
+SONIC_DOCKER_BRD_PATTERN = "^docker(\d+)$"
 
 class BaseIdx:
     ethernet_base_idx = 1
@@ -25,6 +26,7 @@ class BaseIdx:
     mgmt_port_base_idx = 10000
     ethernet_ib_base_idx = 11000
     ethernet_rec_base_idx = 12000
+    docker_brd_base_idx = 4000
 
 def get_index(if_name):
     """
@@ -36,6 +38,7 @@ def get_index(if_name):
     eth N = N + 10000
     Ethernet_IB N = N + 11000
     Ethernet_Rec N = N + 12000
+    docker_brdg N = N + 4000
     """
     return get_index_from_str(if_name.decode())
 
@@ -50,6 +53,7 @@ def get_index_from_str(if_name):
     eth N = N + 10000
     Ethernet_IB N = N + 11000
     Ethernet_Rec N = N + 12000
+    docker_brdg N = N + 4000
     """
     patterns = {
         SONIC_ETHERNET_RE_PATTERN: BaseIdx.ethernet_base_idx,
@@ -58,7 +62,8 @@ def get_index_from_str(if_name):
         SONIC_PORTCHANNEL_RE_PATTERN: BaseIdx.portchannel_base_idx,
         SONIC_MGMT_PORT_RE_PATTERN: BaseIdx.mgmt_port_base_idx,
         SONIC_ETHERNET_IB_RE_PATTERN: BaseIdx.ethernet_ib_base_idx,
-        SONIC_ETHERNET_REC_RE_PATTERN: BaseIdx.ethernet_rec_base_idx
+        SONIC_ETHERNET_REC_RE_PATTERN: BaseIdx.ethernet_rec_base_idx,
+        SONIC_DOCKER_BRD_PATTERN: BaseIdx.docker_brd_base_idx
     }
 
     for pattern, baseidx in patterns.items():


### PR DESCRIPTION
- What I did
It is an extension PR of [PR#284](https://github.com/sonic-net/sonic-snmpagent/pull/284) which is adding support of IpaddressifIndex MIB [OID: OID 1.3.6.1.2.1.4.34.1.3]  support.

This will eventually fix [issue#15359](https://github.com/sonic-net/sonic-buildimage/issues/15359).

- How I did it
Added section for docker bridge interface so that get_index_from_str() will return the correct IfIndex for docker0 bridge interface.

- How to verify it

root@sonic:~# show ip int
Interface     Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
------------  --------  -------------------  ------------  --------------  -------------
Ethernet0              172.21.227.120/31    up/up         N/A             N/A
Ethernet8              172.21.227.122/31    up/up         N/A             N/A
docker0                 240.127.1.1/24       up/down       N/A             N/A
eth0                    10.4.4.85/23         up/up         N/A             N/A
lo                      127.0.0.1/16         up/up         N/A             N/A

root@sonic:~# ip addr show docker0
5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
    link/ether 02:42:b3:6d:c9:52 brd ff:ff:ff:ff:ff:ff
    inet 240.127.1.1/24 brd 240.127.1.255 scope global docker0
       valid_lft forever preferred_lft forever
    inet6 fd00::1/80 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::1/64 scope link 
       valid_lft forever preferred_lft forever

root@sonic:~# ip addr show Bridge
42: Bridge: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN group default qlen 1000
    link/ether 00:30:64:6a:fa:a3 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::1837:a4ff:fed5:3cfd/64 scope link 
       valid_lft forever preferred_lft forever

root@sonic:/# snmpwalk -v2c -c <comm> localhost 1.3.6.1.2.1.4.34.1.3
iso.3.6.1.2.1.4.34.1.3.1.4.172.21.227.120 = INTEGER: 1
iso.3.6.1.2.1.4.34.1.3.1.4.172.21.227.122 = INTEGER: 9
iso.3.6.1.2.1.4.34.1.3.1.4.10.4.4.85 = INTEGER: 10000
iso.3.6.1.2.1.4.34.1.3.1.4.240.127.1.1 = INTEGER: 4000
iso.3.6.1.2.1.4.34.1.3.1.4.240.127.1.255 = INTEGER: 4000
iso.3.6.1.2.1.4.34.1.3.2.16.253.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1 = INTEGER: 4000
iso.3.6.1.2.1.4.34.1.3.2.16.254.128.0.0.0.0.0.0.0.0.0.0.0.0.0.1 = INTEGER: 4000
iso.3.6.1.2.1.4.34.1.3.2.16.254.128.0.0.0.0.0.0.2.48.100.255.254.106.250.163 = INTEGER: 10000
iso.3.6.1.2.1.4.34.1.3.2.16.254.128.0.0.0.0.0.0.24.55.164.255.254.213.60.253 = INTEGER: 4000

**- Another PR linkage**
[PR#284](https://github.com/sonic-net/sonic-snmpagent/pull/284)