### PR TITLE
Add a new API connect_host to SonicV2Connector

### DIFF
--- a/src/swsssdk/dbconnector.py
+++ b/src/swsssdk/dbconnector.py
@@ -267,6 +267,13 @@ class SonicV2Connector(object):
         db_id = self.get_dbid(db_name)
         self.dbintf.connect(db_id, db_name, retry_on)
 
+    def connect_host(self, db_name, host, retry_on=True):
+        self.dbintf.redis_kwargs["host"] = host
+        self.dbintf.redis_kwargs["port"] = self.get_db_port(db_name)
+        self.dbintf.redis_kwargs["unix_socket_path"] = None
+        db_id = self.get_dbid(db_name)
+        self.dbintf.connect(db_id, db_name, retry_on)
+
     def close(self, db_name):
         self.dbintf.close(db_name)
 


### PR DESCRIPTION
This feature has been tracked in https://github.com/sonic-net/SONiC/issues/1543

### What did I do?

A new API is being added to sonicv2connector.cpp which can take the db name and host IP as an argument and connect us to the redis instance. The existing [API](https://github.com/sonic-net/sonic-swss-common/blob/202411/common/sonicv2connector.cpp#L18-L30) needs the db_name and the host_ip and port (or unix_socket) is decoded using [database_config.json](https://github.com/sonic-net/sonic-buildimage/blob/master/dockers/docker-database/database_config.json.j2). This API is tailored for use cases when you want to connect to the namespace redis instances from the same device. Our use case of aggregating VOQ counters across NPUs involves connecting to a redis instances over midplane IP hence the new API is needed.

### How did I test it?
A unit test will be added to sonic-utilities and put this to use. Also verified on Arista chassis (DCS-7804-CH) which had 7800R3A-36D2-LC linecards with all changes related to this feature as present here https://github.com/sonic-net/SONiC/pull/1957